### PR TITLE
Fix API URLs imports

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -1,8 +1,7 @@
 from django.urls import path
-from .views import PredictionAPIView, CalculateTHIAPIView
+from .views import CalculateTHIAPIView
 
 
 urlpatterns = [
-    # path('predict/', PredictionAPIView.as_view(), name='predict-api'),
     path('calculate_thi/', CalculateTHIAPIView.as_view(), name='calculate-thi-api'),
 ]


### PR DESCRIPTION
## Summary
- update URLs to import only `CalculateTHIAPIView`
- keep only the THI route

## Testing
- `python -m py_compile api/urls.py`
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6858062720ac832aa6fed991e61858b4