### PR TITLE
Fix duplicate URL entry

### DIFF
--- a/myproject/urls.py
+++ b/myproject/urls.py
@@ -6,7 +6,6 @@ urlpatterns = [
     path('', include('ui.urls')),  # Route for the main UI
     path('auth/', include('authentication.urls')),
     # path('dashboard/', include('ui.urls')),
-    path('django_plotly_dash/', include('django_plotly_dash.urls')),  
     path('django_plotly_dash/', include('django_plotly_dash.urls')),
     path('api/', include('api.urls')),
 ]


### PR DESCRIPTION
## Summary
- remove duplicate route for `django_plotly_dash` in main urlconf

## Testing
- `python -m py_compile myproject/urls.py`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6858080f94dc832a8ff912e155be69b6