### PR TITLE
Relax iframe sizing

### DIFF
--- a/ui/static/css/style.css
+++ b/ui/static/css/style.css
@@ -1790,19 +1790,19 @@ padding:50px 0
     padding: 0;
     margin: 0;
     width: 100%;
-    height: calc(100vh - 60px); /* Adjust based on header height if needed */
-    overflow: hidden;
+    /* Provide a minimum height but allow the app to expand as needed */
+    min-height: calc(100vh - 60px);
 }
 
 .dash-app {
     width: 100%;
-    height: 100%;
-    overflow: hidden;
 }
 
 .dash-app iframe {
     width: 100%;
-    height: 100%;
+    height: auto;
+    /* Ensure the iframe is tall enough for its content */
+    min-height: 600px;
     border: none;
 }
 


### PR DESCRIPTION
## Summary
- relax CSS rules so the Dash app grows with its content

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py collectstatic --noinput` *(fails: Couldn't import Django)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68580a25c9fc832a845906b993541b35