### PR TITLE
Add dpd-static-support

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     'ui',
     'authentication',
     'django_plotly_dash',
+    'dpd_static_support',
     'rest_framework',
     'api',
     'compressor',

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-appconf==1.1.0
 django-compressor==4.5.1
 django-crispy-forms==2.4
 django-plotly-dash==2.4.6
+dpd-static-support
 djangorestframework==3.16.0
 joblib==1.5.1
 keras==3.10.0


### PR DESCRIPTION
## Summary
- include `dpd-static-support` in `requirements.txt`
- register `dpd_static_support` in `INSTALLED_APPS`

## Testing
- `pip install dpd-static-support` *(fails: no internet)*
- `python manage.py collectstatic --noinput` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68583d79ed00832a93cc348e19db243c