### PR TITLE
Add Dash static finders

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     'ui',
     'authentication',
     'django_plotly_dash',
+    'dpd_static_support',
     'rest_framework',
     'api',
     'compressor',
@@ -153,5 +154,18 @@ COMPRESS_ENABLED = True
 STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'django_plotly_dash.finders.DashAssetFinder',
+    'django_plotly_dash.finders.DashComponentFinder',
+    'django_plotly_dash.finders.DashAppDirectoryFinder',
     'compressor.finders.CompressorFinder',
+]
+
+# Packages that supply Dash component bundles
+PLOTLY_COMPONENTS = [
+    'dash_core_components',
+    'dash_html_components',
+    'dash_renderer',
+    'dpd_components',
+    'dpd_static_support',
+    'dash_bootstrap_components',
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-appconf==1.1.0
 django-compressor==4.5.1
 django-crispy-forms==2.4
 django-plotly-dash==2.4.6
+dpd-static-support
 djangorestframework==3.16.0
 joblib==1.5.1
 keras==3.10.0


### PR DESCRIPTION
## Summary
- configure Dash static finders and components for collectstatic

## Testing
- `pip install dpd-static-support` *(fails: no internet)*
- `python manage.py collectstatic --noinput` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68583d79ed00832a93cc348e19db243c