### PR TITLE
Fix dashboard iframe height

### DIFF
--- a/ui/static/css/style.css
+++ b/ui/static/css/style.css
@@ -1801,8 +1801,6 @@ padding:50px 0
 .dash-app iframe {
     width: 100%;
     height: auto;
-    /* Ensure the iframe is tall enough for its content */
-    min-height: 600px;
     border: none;
 }
 

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -38,5 +38,15 @@
       {% plotly_app name="dashapp" %}
     </div>
   </div>
+  <script>
+    const iframe = document.querySelector('.dash-app iframe');
+    if (iframe) {
+      iframe.setAttribute('scrolling', 'no');
+      iframe.style.overflow = 'hidden';
+      iframe.addEventListener('load', () => {
+        iframe.style.height = iframe.contentWindow.document.body.scrollHeight + 'px';
+      });
+    }
+  </script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- resize Dash iframe to content height once loaded
- remove min-height on iframe

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685847abe068832ab8f173bc61809d94