### PR TITLE
Fix README instructions for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Django and Dash project providing an interactive data management interface.
 
 1. Install dependencies:
    ```bash
-   pip install -r requirements-clean.txt
+   pip install -r requirements.txt
    ```
 2. Run migrations:
    ```bash


### PR DESCRIPTION
## Summary
- update setup instructions to reference `requirements.txt`

## Testing
- `python check_sneat.py` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68584f6813a0832aab9910a7d86e12fb