### PR TITLE
Require secret key in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ A Django and Dash project providing an interactive data management interface.
    ```bash
    python manage.py runserver
    ```
+   
+Before running any Django commands, set a secret key in the environment:
+```bash
+export DJANGO_SECRET_KEY='your-strong-secret-key'
+```

--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 from pathlib import Path
 import os
 from django.contrib.messages import constants as messages
+from django.core.exceptions import ImproperlyConfigured
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -23,7 +24,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
-SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'fallback-insecure-dev-key')
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
+if not SECRET_KEY:
+    raise ImproperlyConfigured(
+        "The DJANGO_SECRET_KEY environment variable is required and missing."
+    )
 DEBUG = os.getenv('DJANGO_DEBUG', 'True') == 'True'
 
 ALLOWED_HOSTS = ['localhost', '127.0.0.1','dmsplatform.pro', 'www.dmsplatform.pro', '185.215.244.171']


### PR DESCRIPTION
## Summary
- enforce DJANGO_SECRET_KEY presence in settings
- document secret key setup in README

## Testing
- `DJANGO_SECRET_KEY=test python manage.py test` *(fails: ModuleNotFoundError: No module named 'keras')*

------
https://chatgpt.com/codex/tasks/task_e_68584f782594832abec915385c44794b