### PR TITLE
Add license and improve project README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2025 ET4D DMS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,33 @@
 # DMS
 
-A Django and Dash project providing an interactive data management interface.
+DMS (Data Management System) combines Django with Dash to provide interactive dashboards and APIs for handling data ingestion, processing and visualization.
 
 ## Setup
 
-1. Install dependencies:
+1. Clone the repository and create a virtual environment.
+2. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-2. Run migrations:
+3. Configure environment variables (for development add them to `.env` or your shell profile):
+   ```bash
+   export DJANGO_SECRET_KEY=your_secret_key
+   export DJANGO_DEBUG=True
+   ```
+   The application uses SQLite by default, but you can adjust database settings in `myproject/settings.py`.
+4. Run migrations:
    ```bash
    python manage.py migrate
    ```
-3. Start the development server:
+5. Create an admin user:
+   ```bash
+   python manage.py createsuperuser
+   ```
+6. Start the development server:
    ```bash
    python manage.py runserver
    ```
+
+## Usage
+
+After starting the server, visit `http://127.0.0.1:8000` to access the web interface and dashboards. Log in with the superuser credentials to manage data and users.


### PR DESCRIPTION
## Summary
- expand README with project overview, setup, and usage
- add an MIT license for clarity

## Testing
- `python manage.py test` *(fails: No module named 'django_plotly_dash')*

------
https://chatgpt.com/codex/tasks/task_e_685883c7cc90832aad237ba7b755588e