### PR TITLE
Add diagnostics for Dash integration

### DIFF
--- a/ui/apps.py
+++ b/ui/apps.py
@@ -1,9 +1,11 @@
 from django.apps import AppConfig
+import logging
 
 
 class UiConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'ui'
-    
+
     def ready(self):
         import ui.dashapp
+        logging.getLogger(__name__).info("UiConfig.ready: dashapp imported")

--- a/ui/dashapp.py
+++ b/ui/dashapp.py
@@ -5,15 +5,23 @@ from dash import dcc, html, Input, Output
 import pandas as pd
 import plotly.express as px
 import os
+import logging
 from django_plotly_dash import DjangoDash
 from data_management.data_loader import load_data
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.info("Initializing Dash app")
+
 
 # Load hourly aggregated data
+logger.info("Loading data for dashapp")
 try:
     df = load_data('hourly_merged_sensor_data.csv')
+    logger.info("Data loaded successfully with shape %s", df.shape)
 except FileNotFoundError as e:
-    print(e)
+    logger.exception("Data file could not be loaded: %s", e)
+    df = pd.DataFrame()
     
 # from flask_cors import CORS
 

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -41,11 +41,14 @@
   <script>
     const iframe = document.querySelector('.dash-app iframe');
     if (iframe) {
+      console.log('Dash iframe found:', iframe.src);
       iframe.setAttribute('scrolling', 'no');
       iframe.style.overflow = 'hidden';
       iframe.addEventListener('load', () => {
         iframe.style.height = iframe.contentWindow.document.body.scrollHeight + 'px';
       });
+    } else {
+      console.log('Dash iframe not found');
     }
   </script>
 {% endblock %}

--- a/ui/views.py
+++ b/ui/views.py
@@ -128,9 +128,10 @@ def get_chart_data(request):
     return JsonResponse({'data': chart_data, 'statistics': statistics})
 
 def dashboard(request):
+    logger.info("Rendering dashboard view")
     days = int(request.GET.get('days', 90))  # Default to 90 days if not specified
     chart_data, parameters = process_dataframes(days)  # Call the new function to process dataframes
-    print(parameters)
+    logger.debug("Dashboard parameters: %s", parameters)
 
     chart_data_json = json.dumps(chart_data, ensure_ascii=False)
     return render(request, 'dashboard.html', {


### PR DESCRIPTION
## Summary
- log when Dash app loads
- log dashboard view requests
- add iframe load diagnostic logs on dashboard page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6858896233c8832ab717c75663ea7f99