### PR TITLE
Expose THI helper and refactor usage

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -8,12 +8,17 @@ from .views import PredictionAPIView
 class CalculateTHIAPITestCase(APITestCase):
     @patch('api.views.calculate_thi')
     def test_calculate_thi_api(self, mock_calculate):
-        df = pd.DataFrame([{'Timestamp': '2024-01-01T00:00:00', 'THI': 50}])
-        mock_calculate.return_value = df
+        df_de = pd.DataFrame([{"datetime": "2024-01-01T00:00:00", "thi": 50}])
+        df_pl = pd.DataFrame([{"datetime": "2024-01-01T00:00:00", "thi": 40}])
+        mock_calculate.return_value = (df_de, df_pl)
         url = reverse('calculate-thi-api')
         response = self.client.get(url)
+        expected = {
+            'Germany': df_de.to_dict(orient='records'),
+            'Poland': df_pl.to_dict(orient='records'),
+        }
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), df.to_json(orient='records', date_format='iso'))
+        self.assertEqual(response.json(), expected)
 
 class PredictionAPITestCase(APITestCase):
     @patch('api.views.make_prediction')

--- a/api/views.py
+++ b/api/views.py
@@ -16,10 +16,15 @@ class PredictionAPIView(APIView):
 class CalculateTHIAPIView(APIView):
     def get(self, request):
         try:
-            thi_data = calculate_thi()
-            # Convert DataFrame to JSON
-            thi_json = thi_data.to_json(orient='records', date_format='iso')
-            return JsonResponse(thi_json, safe=False)
+            germany_thi_data, poland_thi_data = calculate_thi()
+            germany_thi_json = germany_thi_data.to_json(orient='records', date_format='iso')
+            poland_thi_json = poland_thi_data.to_json(orient='records', date_format='iso')
+
+            response_data = {
+                'Germany': json.loads(germany_thi_json),
+                'Poland': json.loads(poland_thi_json)
+            }
+            return JsonResponse(response_data, safe=False)
         except Exception as e:
             return JsonResponse({'error': str(e)}, status=500)
 

--- a/data_management/calculate_thi.py
+++ b/data_management/calculate_thi.py
@@ -3,34 +3,43 @@
 import pandas as pd
 import os
 
-def calculate_thi():
-    # Define the base directory and file paths
-    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    germany_file = os.path.join(base_dir, 'data', 'processed', 'Germany', 'hourly_merged_sensor_data.csv')  # Adjust the filename
-    poland_file = os.path.join(base_dir, 'data', 'processed', 'Poland', 'hourly_merged_sensor_data.csv')  # Adjust the filename
 
-    # Load the data
+def add_thi_column(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of ``df`` with an additional ``thi`` column."""
+    if df.empty:
+        return df.copy()
+
+    result = df.copy()
+    result["thi"] = (
+        (1.8 * result["temperature"] + 32)
+        - ((0.55 - 0.0055 * result["humidity"]) * (1.8 * result["temperature"] - 26))
+    )
+    return result
+
+def calculate_thi():
+    """Load Germany and Poland data and append a THI column.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, pd.DataFrame]
+        DataFrames for Germany and Poland, each with an added ``thi`` column.
+    """
+
+    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    germany_file = os.path.join(
+        base_dir, "data", "processed", "Germany", "hourly_merged_sensor_data.csv"
+    )
+    poland_file = os.path.join(
+        base_dir, "data", "processed", "Poland", "hourly_merged_sensor_data.csv"
+    )
+
     germany_data = pd.read_csv(germany_file)
     poland_data = pd.read_csv(poland_file)
 
-    # Assuming the columns for temperature and humidity are named 'Temperature' and 'Humidity'
-    # You may need to adjust these names based on your actual CSV structure
-    germany_thi_data = []
-    poland_thi_data = []
-    
-    for index, row in germany_data.iterrows():
-        temperature = row['temperature']
-        humidity = row['humidity']
-        thi = (1.8 * temperature + 32) - ((0.55 - 0.0055 * humidity) * (1.8 * temperature - 26))
-        germany_thi_data.append({'Timestamp': row['datetime'], 'THI': thi})
+    germany_data = add_thi_column(germany_data)
+    poland_data = add_thi_column(poland_data)
 
-    for index, row in poland_data.iterrows():
-        temperature = row['temperature']
-        humidity = row['humidity']
-        thi = (1.8 * temperature + 32) - ((0.55 - 0.0055 * humidity) * (1.8 * temperature - 26))
-        poland_thi_data.append({'Timestamp': row['datetime'], 'THI': thi})
-
-    return pd.DataFrame(germany_thi_data), pd.DataFrame(poland_thi_data)
+    return germany_data, poland_data
 
 # You can now test your API by sending a GET request to /api/calculate_thi/. This will return the THI data in JSON format.
 

--- a/ui/dashapp.py
+++ b/ui/dashapp.py
@@ -8,6 +8,7 @@ import os
 import logging
 from django_plotly_dash import DjangoDash
 from data_management.data_loader import load_data
+from data_management.calculate_thi import add_thi_column
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -24,17 +25,9 @@ try:
     df_germany['datetime'] = pd.to_datetime(df_germany['datetime'], utc=True)
     df_poland['datetime'] = pd.to_datetime(df_poland['datetime'], utc=True)
 
-    # Calculate THI for each row using temperature and humidity
-    df_germany["thi"] = (
-        (1.8 * df_germany["temperature"] + 32)
-        - ((0.55 - 0.0055 * df_germany["humidity"])
-           * (1.8 * df_germany["temperature"] - 26))
-    )
-    df_poland["thi"] = (
-        (1.8 * df_poland["temperature"] + 32)
-        - ((0.55 - 0.0055 * df_poland["humidity"])
-           * (1.8 * df_poland["temperature"] - 26))
-    )
+    # Append THI column using shared helper
+    df_germany = add_thi_column(df_germany)
+    df_poland = add_thi_column(df_poland)
 
     dataframes = {
         'Germany': df_germany,

--- a/ui/views.py
+++ b/ui/views.py
@@ -13,8 +13,15 @@ logger = logging.getLogger(__name__)
 from data_management.calculate_thi import calculate_thi  # Import the function
 
 def get_thi_data(request):
-    thi_data = calculate_thi()  # Call the function to calculate THI
-    thi_data_json = thi_data.to_json(orient='records', date_format='iso')  # Convert to JSON
+    germany_data, poland_data = calculate_thi()
+    thi_data = pd.concat(
+        [
+            germany_data[["datetime", "thi"]].assign(country="Germany"),
+            poland_data[["datetime", "thi"]].assign(country="Poland"),
+        ],
+        ignore_index=True,
+    )
+    thi_data_json = thi_data.to_json(orient="records", date_format="iso")
     return JsonResponse(thi_data_json, safe=False)
 
 # Views for static pages

--- a/ui/views_postgres.py
+++ b/ui/views_postgres.py
@@ -14,8 +14,15 @@ logger = logging.getLogger(__name__)
 from data_management.calculate_thi import calculate_thi  # Import the function
 
 def get_thi_data(request):
-    thi_data = calculate_thi()  # Call the function to calculate THI
-    thi_data_json = thi_data.to_json(orient='records', date_format='iso')  # Convert to JSON
+    germany_data, poland_data = calculate_thi()
+    thi_data = pd.concat(
+        [
+            germany_data[["datetime", "thi"]].assign(country="Germany"),
+            poland_data[["datetime", "thi"]].assign(country="Poland"),
+        ],
+        ignore_index=True,
+    )
+    thi_data_json = thi_data.to_json(orient="records", date_format="iso")
     return JsonResponse(thi_data_json, safe=False)
 
 # Views for static pages


### PR DESCRIPTION
## Summary
- add `add_thi_column` helper for appending a THI column
- refactor `calculate_thi()` to use the helper
- integrate helper into Dash app
- update API to return THI data for Germany and Poland
- update views and tests for new return format

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68591a1f4030832ab9b9ad60cc82f72e