### PR TITLE
Fix crispy bootstrap template issue

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     'api',
     'compressor',
     'crispy_forms',
+    'crispy_bootstrap4',
 ]
 
 MIDDLEWARE = [
@@ -160,3 +161,4 @@ STATICFILES_FINDERS = [
 
 # Use Bootstrap 4 styling for django-crispy-forms
 CRISPY_TEMPLATE_PACK = "bootstrap4"
+CRISPY_ALLOWED_TEMPLATE_PACKS = ["bootstrap4"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Django==5.0
 django-appconf==1.1.0
 django-compressor==4.5.1
 django-crispy-forms==2.4
+crispy-bootstrap4==2025.6
 django-cors-headers==4.3.1
 django-plotly-dash==2.3.1
 django-tailwind==3.8.0


### PR DESCRIPTION
## Summary
- install `crispy-bootstrap4`
- enable `crispy_bootstrap4` app
- allow bootstrap4 templates

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`
- `python manage.py shell -c "from django.template import loader; loader.get_template('bootstrap4/field.html'); print('template found')"`


------
https://chatgpt.com/codex/tasks/task_e_68592c89a250832a9a2797abd257469a