### PR TITLE
Improve contact image styles

### DIFF
--- a/ui/templates/contact.html
+++ b/ui/templates/contact.html
@@ -13,10 +13,11 @@
 
     <!-- ── Dr Sabrina Hempel ── -->
     <div class="col-sm-6 col-lg-4">
-      <div class="card h-100 shadow-sm">
-        <img src="{% static 'img/people/Sabrina.jpg' %}"
-             class="card-img-top" alt="Dr Sabrina Hempel">
-        <div class="card-body">
+      <div class="card h-100 shadow-sm text-center">
+        <div class="card-body d-flex flex-column align-items-center">
+          <img src="{% static 'img/People/Sabrina.jpg' %}"
+               class="rounded-circle mb-3 shadow"
+               style="width:150px;height:150px;object-fit:cover;" alt="Dr Sabrina Hempel">
           <h6 class="card-title mb-1">Dr Sabrina Hempel</h6>
           <p class="text-muted small mb-2">Project coordinator</p>
           <ul class="list-unstyled small lh-lg mb-0">
@@ -29,16 +30,17 @@
             <li><strong>Address:</strong><br>
                 Max-Eyth-Allee 100<br>14469 Potsdam | DE</li>
           </ul>
-        </div>
+        </div><!--/card-body-->
       </div>
     </div>
 
     <!-- ── Prof Thomas Banhazi ── -->
     <div class="col-sm-6 col-lg-4">
-      <div class="card h-100 shadow-sm">
-        <img src="{% static 'img/people/Thomas-Banhazi.jpg' %}"
-             class="card-img-top" alt="Prof Thomas Banhazi">
-        <div class="card-body">
+      <div class="card h-100 shadow-sm text-center">
+        <div class="card-body d-flex flex-column align-items-center">
+          <img src="{% static 'img/People/Thomas-Banhazi.jpg' %}"
+               class="rounded-circle mb-3 shadow"
+               style="width:150px;height:150px;object-fit:cover;" alt="Prof Thomas Banhazi">
           <h6 class="card-title mb-1">Prof Thomas Banhazi</h6>
           <p class="text-muted small mb-2">University of Southern Queensland</p>
           <!-- Add phone or email if desired -->


### PR DESCRIPTION
## Summary
- refactor contact page team cards
- show circular contact images similar to communication page
- enlarge contact portraits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6018bd94832a89c336adb485e0bb