### PR TITLE
Fix static image references

### DIFF
--- a/ui/templates/about.html
+++ b/ui/templates/about.html
@@ -21,7 +21,7 @@
       <div class="card">
         <div class="card-body">
           <h5 class="card-title">Timeline</h5>
-          <img src="{% static 'sneat/assets/img/illustrations/page-misc-under-maintenance.png' %}" alt="timeline" class="img-fluid">
+          <img src="{% static 'sneat/assets/img/illustrations/man-with-laptop-light.png' %}" alt="timeline" class="img-fluid">
         </div>
       </div>
     </div>

--- a/ui/templates/partials/navbar.html
+++ b/ui/templates/partials/navbar.html
@@ -19,8 +19,8 @@
         <li class="nav-item navbar-dropdown dropdown-user dropdown">
           <a class="nav-link dropdown-toggle hide-arrow" href="#" data-bs-toggle="dropdown">
             <div class="avatar avatar-online">
-              {# Load default avatar from static/img/People #}
-              <img src="{% static 'img/People/default-user.png' %}"
+              {# Load default avatar from static/img #}
+              <img src="{% static 'img/avatar.png' %}"
                    alt
                    class="w-px-40 h-auto rounded-circle" />
             </div>
@@ -31,7 +31,7 @@
                 <div class="d-flex">
                   <div class="flex-shrink-0 me-3">
                     <div class="avatar avatar-online">
-                      <img src="{% static 'img/People/default-user.png' %}"
+                      <img src="{% static 'img/avatar.png' %}"
                            alt
                            class="w-px-40 h-auto rounded-circle" />
                     </div>


### PR DESCRIPTION
## Summary
- reference existing avatar.png in navbar
- use available man-with-laptop-light.png in about page

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685d21b7528c832a8e04bc5cada12ded