### PR TITLE
Add Allerts page to UI

### DIFF
--- a/ui/templates/allerts.html
+++ b/ui/templates/allerts.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block title %}Allerts • ET4D{% endblock %}
+
+{% block content %}
+<div class="container-xxl flex-grow-1 container-p-y">
+  <h4 class="fw-bold mb-4">
+    <span class="text-muted fw-light">Monitoring /</span> Allerts
+  </h4>
+
+  <div class="row mb-4">
+    <div class="col-12 col-lg-8">
+      <h5>EU-recommended thresholds</h5>
+      <ul>
+        <li>Ammonia: below 9.5 ppm</li>
+        <li>Carbon dioxide: below 2850 ppm</li>
+        <li>Airborne dust (particulate matter): below 200 µg/m³</li>
+        <li>Relative humidity: 30 – 80 %</li>
+        <li>Temperature: 20 – 24 °C</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <h5>Percentage of time outside the recommended range</h5>
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th>Farm</th>
+            <th>Ammonia</th>
+            <th>CO₂</th>
+            <th>Dust</th>
+            <th>Humidity</th>
+            <th>Temperature</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Germany Farm</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Poland Farm</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/ui/templates/partials/sidebar.html
+++ b/ui/templates/partials/sidebar.html
@@ -36,6 +36,13 @@
       </a>
     </li>
 
+    <li class="menu-item{% if request.resolver_match.url_name == 'allerts' %} active{% endif %}">
+      <a href="{% url 'allerts' %}" class="menu-link">
+        <i class="menu-icon tf-icons bx bx-error"></i>
+        <div>Allerts</div>
+      </a>
+    </li>
+
     <li class="menu-item{% if request.resolver_match.url_name == 'survey' %} active{% endif %}">
       <a href="{% url 'survey' %}" class="menu-link">
         <i class="menu-icon tf-icons bx bx-edit"></i>

--- a/ui/tests.py
+++ b/ui/tests.py
@@ -6,6 +6,11 @@ class HomePageTests(TestCase):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
 
+    def test_allerts_page_loads(self):
+        response = self.client.get('/allerts/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'EU-recommended thresholds')
+
 class StatisticsFunctionTests(TestCase):
     def test_calculate_statistics(self):
         chart_data = [

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path('', views.index, name='index'),
     path('about/', views.about, name='about'),
     path('dashboard/', views.dashboard, name='dashboard'),
+    path('allerts/', views.allerts, name='allerts'),
     path('contact/', views.contact, name='contact'),
     path('survey/', views.survey, name='survey'),
     path('communication/', views.communication, name='communication'),

--- a/ui/views.py
+++ b/ui/views.py
@@ -146,6 +146,10 @@ def dashboard(request):
         'parameters': parameters  # Pass parameters to the template
     })
 
+def allerts(request):
+    """Display threshold information and placeholder alert stats."""
+    return render(request, 'allerts.html')
+
 def contact(request):
     return render(request, 'contact.html')
 

--- a/ui/views_postgres.py
+++ b/ui/views_postgres.py
@@ -161,6 +161,10 @@ def dashboard(request):
         'parameters': parameters  # Pass parameters to the template
     })
 
+def allerts(request):
+    """Display threshold information and placeholder alert stats."""
+    return render(request, 'allerts.html')
+
 def contact(request):
     return render(request, 'contact.html')
 


### PR DESCRIPTION
## Summary
- introduce Allerts page with EU thresholds and placeholder stats
- wire page into views, URLs and sidebar navigation
- add basic Allerts page test

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6863a40f5660832a915c1dc73fc0cedb