### PR TITLE
Move dashboard header into template

### DIFF
--- a/ui/dashapp.py
+++ b/ui/dashapp.py
@@ -71,10 +71,6 @@ feature_groups = {
 
 app.layout = html.Div(
     [
-        html.H1(
-            "Dashboard",
-            style={"textAlign": "center"},
-        ),
         # --- Live sensor panel and Environmental footprint ---
         html.Div(
             id="visualization-section",

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -14,6 +14,7 @@
   <!-- Intro section -->
   <div class="row mb-4">
     <div class="col-12 col-lg-8">
+      <h1>Dashboard</h1>
       <p class="lead">
         The Environmental Traits for Dairy (ET4D) dashboard aggregates real-time sensor
         readings, THI calculations and machine-learning forecasts to help you keep herds


### PR DESCRIPTION
## Summary
- move `<h1>` from dash layout into dashboard template
- remove duplicate heading from Dash layout

## Testing
- `pytest -q` *(fails: Unknown config option, no tests run)*
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6863ad396b40832ab531cb69e1106e28