### PR TITLE
Update layout order for visualization and THI sections

### DIFF
--- a/ui/dashapp.py
+++ b/ui/dashapp.py
@@ -133,6 +133,18 @@ app.layout = html.Div(
                             end_date=max_date,
                             display_format="YYYY-MM-DD HH:mm",
                         ),
+                        html.Button(
+                            "Export CSV",
+                            id="export-button",
+                            n_clicks=0,
+                            style={"margin": "10px"},
+                        ),
+                        dcc.Download(id="download-data"),
+                        dcc.Graph(
+                            id="feature-graph",
+                            style={"height": "70vh", "width": "100%"},
+                            config={"responsive": True},
+                        ),
                         html.H3("Live data"),
                         html.Ul(
                             [
@@ -155,18 +167,6 @@ app.layout = html.Div(
                                 ),
                             ]
                         ),
-                        html.Button(
-                            "Export CSV",
-                            id="export-button",
-                            n_clicks=0,
-                            style={"margin": "10px"},
-                        ),
-                        dcc.Download(id="download-data"),
-                        dcc.Graph(
-                            id="feature-graph",
-                            style={"height": "70vh", "width": "100%"},
-                            config={"responsive": True},
-                        ),
                     ],
                 )
             ],
@@ -188,6 +188,18 @@ app.layout = html.Div(
                             "Additional animal welfare metrics will be integrated later.",
                             className="text-center text-muted",
                         ),
+                        dcc.Graph(
+                            id="thi-graph",
+                            style={"height": "70vh", "width": "100%"},
+                            config={"responsive": True},
+                        ),
+                        html.Button(
+                            "Export THI CSV",
+                            id="export-thi-button",
+                            n_clicks=0,
+                            style={"margin": "10px"},
+                        ),
+                        dcc.Download(id="download-thi-data"),
                         html.H3("Live data"),
                         html.Ul(
                             [
@@ -207,18 +219,6 @@ app.layout = html.Div(
                                 ),
                             ]
                         ),
-                        dcc.Graph(
-                            id="thi-graph",
-                            style={"height": "70vh", "width": "100%"},
-                            config={"responsive": True},
-                        ),
-                        html.Button(
-                            "Export THI CSV",
-                            id="export-thi-button",
-                            n_clicks=0,
-                            style={"margin": "10px"},
-                        ),
-                        dcc.Download(id="download-thi-data"),
                     ],
                 )
             ],


### PR DESCRIPTION
## Summary
- move data description lists below the export buttons and graphs in dashboard layout

## Testing
- `python manage.py test ui`

------
https://chatgpt.com/codex/tasks/task_e_6863ad592bf8832a94d6b5a98649fc63