### PR TITLE
Fix dash placeholder test

### DIFF
--- a/ui/dashapp.py
+++ b/ui/dashapp.py
@@ -347,6 +347,7 @@ app.layout = html.Div(
                             [
                                 html.Li("Current electricity usage - Later will be available"),
                                 html.Li("Total consumption - Later will be available"),
+                                html.Li("In Turkey (annual entry): Annual energy consumption."),
                             ]
                         ),
                     ],


### PR DESCRIPTION
## Summary
- include energy consumption placeholder for Turkey

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6863b4dec5c0832a8036e83580de892a