### PR TITLE
Fix requirements filename in deployment guide

### DIFF
--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -20,7 +20,7 @@ python -m venv venv
 .\venv\Scripts\Activate.ps1
 
 # Install production dependencies
-pip install -r requirements-prod.txt
+pip install -r requirements.txt
 ```
 
 ## 2. Django Production Settings
@@ -142,7 +142,7 @@ cd C:\path\to\DMS
 git pull
 
 # Install dependencies (if changed)
-pip install -r requirements-prod.txt
+pip install -r requirements.txt
 
 # Collect static files
 python manage.py collectstatic --noinput


### PR DESCRIPTION
## Summary
- update `deployment-guide.md` references to use `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68665d929090832a9cb2c8dd4158af68